### PR TITLE
Fixed locale decimal point when editing products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
-# AbanteCart
+# AbanteCart eCommerce Platform [![Build Status](https://travis-ci.org/abantecart/abantecart-src.svg?branch=master)](https://travis-ci.org/abantecart/abantecart-src)
+
 
 ## Overview
 

--- a/public_html/admin/controller/pages/catalog/product.php
+++ b/public_html/admin/controller/pages/catalog/product.php
@@ -814,20 +814,20 @@ class ControllerPagesCatalogProduct extends AController {
         $this->data['form']['fields']['data']['length'] = $form->getFieldHtml(array(
 			'type' => 'input',
 			'name' => 'length',
-			'value' => $this->data['length'],
+			'value' => localeDisplayFloat($this->data['length'], $this->language->get('decimal_point')),
             'style' => 'tiny-field',
 	    ));
         $this->data['form']['fields']['data']['width'] = $form->getFieldHtml(array(
 			'type' => 'input',
 			'name' => 'width',
-			'value' => $this->data['width'],
+			'value' => localeDisplayFloat($this->data['width'], $this->language->get('decimal_point')),
 	        'attr' => ' autocomplete="false"',
             'style' => 'tiny-field',
 		));
         $this->data['form']['fields']['data']['height'] = $form->getFieldHtml(array(
 			'type' => 'input',
 			'name' => 'height',
-			'value' => $this->data['height'],
+			'value' => localeDisplayFloat($this->data['height'], $this->language->get('decimal_point')),
 	        'attr' => ' autocomplete="false"',
             'style' => 'tiny-field',
 		));
@@ -857,11 +857,10 @@ class ControllerPagesCatalogProduct extends AController {
 		    $this->data['weight_classes'][0] = $this->language->get('text_none');
 	    }
 
-
 		$this->data['form']['fields']['data']['weight'] = $form->getFieldHtml(array(
 			'type' => 'input',
 			'name' => 'weight',
-			'value' => $this->data['weight'],
+			'value' => localeDisplayFloat($this->data['weight'], $this->language->get('decimal_point')),
 			'attr' => ' autocomplete="false"',
             'style' => 'tiny-field',
 		));
@@ -926,7 +925,7 @@ class ControllerPagesCatalogProduct extends AController {
 
 
 	    foreach(array('length', 'width', 'height','weight') as $name){
-		    $this->request->post[$name] = abs($this->request->post[$name]);
+		    $this->request->post[$name] = localeAbs($this->request->post[$name]);
 		    $v =  preformatFloat($this->request->post[$name], $this->language->get('decimal_point'));
             if($v>=1000){
 	            $this->error[$name] = $this->language->get('error_measure_value');

--- a/public_html/core/helper/utils.php
+++ b/public_html/core/helper/utils.php
@@ -26,6 +26,32 @@ function isFunctionAvailable($func_name) {
 }
 
 /*
+ * function abs with locale support
+ * */
+function localeAbs($value, $decimal_point = '.')
+{
+	$value_locale = $value;
+	if ($decimal_point != '.' && strstr($value_locale, $decimal_point)) {
+		$value_locale = str_replace('.', '', $value_locale);
+		$value_locale = str_replace($decimal_point, '.', $value_locale);
+		// doing abs() keeping locale format of decimal point
+		$value = str_replace('.', $decimal_point, abs($value_locale));
+	}
+	return $value;
+}
+
+/*
+ * prepare float to display according to locale decimal point configuration
+ * */
+function localeDisplayFloat($value, $decimal_point = '.') {
+	if ($decimal_point != '.' && strstr($value, '.')) {
+		$value = str_replace($decimal_point, '~', $value);
+		$value = str_replace('.', $decimal_point, $value);
+	}
+	return $value;
+}
+
+/*
  * prepare prices and other floats for database writing,, based on locale settings of number formatting
  * */
 function preformatFloat($value, $decimal_point = '.') {


### PR DESCRIPTION
When installing language extension with "decimal_point" other than dot (.) is causing problems to edit product length, height, width and weight fields. To reproduce the problem, install brazilian portuguese language extension and try to edit product's weight field using decimal value, like 0.8 kg (english format) or 0,8 kg (brazilian format). Both forms will produce another value like 8 kg. The pull request fix that problem.

Another method for testing this bug is changing decimal_point key at language definitions page from dot (.) to comma (,)

![decimal_point_bug1](https://cloud.githubusercontent.com/assets/22223228/18591596/9edc7c7c-7c09-11e6-8fc8-d5a3fa277346.png)

![decimal_point_bug2](https://cloud.githubusercontent.com/assets/22223228/18591606/a6c86180-7c09-11e6-9e61-701ea0144168.png)
