### PR TITLE
Change add cost column method

### DIFF
--- a/public_html/install/abantecart_database_upgrade.sql
+++ b/public_html/install/abantecart_database_upgrade.sql
@@ -1,9 +1,0 @@
-
-ALTER TABLE `ac_product_option_values`
-    ADD COLUMN `cost` DECIMAL(15,4) NOT NULL AFTER `price`;
-
-ALTER TABLE `ac_order_products`
-    ADD COLUMN `cost` DECIMAL(15,4) NOT NULL DEFAULT '0.0000' AFTER `price`;
-
-ALTER TABLE `ac_order_options`
-    ADD COLUMN `cost` DECIMAL(15,4) NOT NULL DEFAULT '0.0000' AFTER `price`;

--- a/public_html/install/abantecart_upgrade.php
+++ b/public_html/install/abantecart_upgrade.php
@@ -1,0 +1,46 @@
+<?php
+
+$this->db->query(
+    "DELETE FROM ".$this->db->table('language_definitions')." 
+    WHERE block='catalog_product' AND language_key = 'entry_product_option_cost'"
+);
+
+$sql = "INSERT INTO ".$this->db->table('language_definitions')."
+        (`language_id`,
+        `section`,
+        `block`,
+        `language_key`,
+        `language_value`, 
+        `date_added`)
+    VALUES 
+( '1', 
+  '1', 
+  'catalog_product', 
+  'entry_product_option_cost',
+  'Actual Cost (total):<span class=\"help\">Enter the actual cost (total) of this product option.</span>',
+  NOW() )";
+$this->db->query($sql);
+
+$sql= "SHOW columns from ".$this->db->table('product_option_values')." where field='cost'";
+$query=$this->db->query($sql);
+$exist=count($query->rows);
+if ($exist==0) {
+    $sql = "ALTER TABLE ".$this->db->table('product_option_values')." ADD `cost` DECIMAL(15,4) NOT NULL AFTER `price`";
+    $this->db->query($sql);
+}
+
+$sql= "SHOW columns from ".$this->db->table('order_products')." where field='cost'";
+$query=$this->db->query($sql);
+$exist=count($query->rows);
+if ($exist==0) {
+    $sql = "ALTER TABLE ".$this->db->table('order_products')." ADD `cost` DECIMAL(15,4) NOT NULL DEFAULT '0.0000' AFTER `price`";
+    $this->db->query($sql);
+}
+
+$sql= "SHOW columns from ".$this->db->table('order_options')." where field='cost'";
+$query=$this->db->query($sql);
+$exist=count($query->rows);
+if ($exist==0) {
+    $sql = "ALTER TABLE ".$this->db->table('order_options')." ADD `cost` DECIMAL(15,4) NOT NULL DEFAULT '0.0000' AFTER `price`";
+    $this->db->query($sql);
+}


### PR DESCRIPTION
Hi core devs,

Sorry for the changes. I change the add cost column from the upgrade.php file instead of using the sql due to we provide a patch for current v1.3.0 users in our site.

I am concern that when v1.3.0 users that already load the patch upgrade to v1.3.1 will get an error during the cart upgrade.