### PR TITLE
set limit based on Default Items per Page (Storefront)

### DIFF
--- a/public_html/storefront/controller/pages/account/download.php
+++ b/public_html/storefront/controller/pages/account/download.php
@@ -75,13 +75,8 @@ class ControllerPagesAccountDownload extends AController
             ]
         );
 
-        if (isset($this->request->get['limit'])) {
-            $limit = (int) $this->request->get['limit'];
-            $limit = $limit > 50 ? 50 : $limit;
-        } else {
-            $limit = $this->config->get('config_catalog_limit');
-        }
-
+        $limit = $this->config->get('config_catalog_limit');
+        
         if ($this->config->get('config_download')) {
             $page = $this->request->get['page'] ?? 1;
             $downloads = [];

--- a/public_html/storefront/controller/pages/account/download.php
+++ b/public_html/storefront/controller/pages/account/download.php
@@ -75,7 +75,11 @@ class ControllerPagesAccountDownload extends AController
             ]
         );
 
-        $limit = $this->config->get('config_catalog_limit');
+        if (isset($this->request->get['limit'])) {
+           $limit = (int) $this->request->get['limit'];
+        } else {  
+           $limit = $this->config->get('config_catalog_limit');
+        }
         
         if ($this->config->get('config_download')) {
             $page = $this->request->get['page'] ?? 1;

--- a/public_html/storefront/controller/pages/account/download.php
+++ b/public_html/storefront/controller/pages/account/download.php
@@ -75,8 +75,8 @@ class ControllerPagesAccountDownload extends AController
             ]
         );
 
-        if (isset($this->request->get['limit'])) {
-           $limit = (int) $this->request->get['limit'];
+        if ((int)$this->request->get['limit'] ) {
+           $limit = min((int) $this->request->get['limit'], 50);
         } else {  
            $limit = $this->config->get('config_catalog_limit');
         }

--- a/public_html/storefront/controller/pages/account/transactions.php
+++ b/public_html/storefront/controller/pages/account/transactions.php
@@ -84,12 +84,7 @@ class ControllerPagesAccountTransactions extends AController
                 $page = 1;
             }
 
-            if (isset($this->request->get['limit'])) {
-                $limit = (int)$this->request->get['limit'];
-                $limit = $limit > 50 ? 50 : $limit;
-            } else {
-                $limit = $this->config->get('config_catalog_limit');
-            }
+            $limit = $this->config->get('config_catalog_limit');
 
             $trans = [];
 

--- a/public_html/storefront/controller/pages/account/transactions.php
+++ b/public_html/storefront/controller/pages/account/transactions.php
@@ -84,7 +84,11 @@ class ControllerPagesAccountTransactions extends AController
                 $page = 1;
             }
 
-            $limit = $this->config->get('config_catalog_limit');
+            if (isset($this->request->get['limit'])) {
+               $limit = (int) $this->request->get['limit'];
+            } else {
+               $limit = $this->config->get('config_catalog_limit');
+            }
 
             $trans = [];
 

--- a/public_html/storefront/controller/pages/product/category.php
+++ b/public_html/storefront/controller/pages/product/category.php
@@ -136,7 +136,12 @@ class ControllerPagesProductCategory extends AController
             $this->data['text_sort'] = $this->language->get('text_sort');
 
             $page = $request['page'] ?? 1;
-            $limit = $this->config->get('config_catalog_limit');
+          
+            if (isset($this->request->get['limit'])) {
+              $limit = (int) $this->request->get['limit'];
+            } else { 
+              $limit = $this->config->get('config_catalog_limit');
+            }
 
             $sorting_href = $request['sort'];
             if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/category.php
+++ b/public_html/storefront/controller/pages/product/category.php
@@ -136,9 +136,7 @@ class ControllerPagesProductCategory extends AController
             $this->data['text_sort'] = $this->language->get('text_sort');
 
             $page = $request['page'] ?? 1;
-            $limit = isset($request['limit'])
-                ? min((int)$request['limit'], 50)
-                : $this->config->get('config_catalog_limit');
+            $limit = $this->config->get('config_catalog_limit');
 
             $sorting_href = $request['sort'];
             if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/collection.php
+++ b/public_html/storefront/controller/pages/product/collection.php
@@ -94,12 +94,8 @@ class ControllerPagesProductCollection extends AController
             $this->view->assign('text_sort', $this->language->get('text_sort'));
 
             $page = $request['page'] ?? 1;
-            if (isset($request['limit'])) {
-                $limit = (int) $request['limit'];
-                $limit = $limit > 50 ? 50 : $limit;
-            } else {
-                $limit = $this->config->get('config_catalog_limit');
-            }
+
+            $limit = $this->config->get('config_catalog_limit');
 
             $sorting_href = $request['sort'];
             if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/collection.php
+++ b/public_html/storefront/controller/pages/product/collection.php
@@ -95,7 +95,11 @@ class ControllerPagesProductCollection extends AController
 
             $page = $request['page'] ?? 1;
 
-            $limit = $this->config->get('config_catalog_limit');
+            if (isset($this->request->get['limit'])) {
+              $limit = (int) $this->request->get['limit'];
+            } else {
+              $limit = $this->config->get('config_catalog_limit');
+            }
 
             $sorting_href = $request['sort'];
             if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/manufacturer.php
+++ b/public_html/storefront/controller/pages/product/manufacturer.php
@@ -131,12 +131,8 @@ class ControllerPagesProductManufacturer extends AController
                 } else {
                     $page = 1;
                 }
-                if (isset($request['limit'])) {
-                    $limit = (int) $request['limit'];
-                    $limit = $limit > 50 ? 50 : $limit;
-                } else {
-                    $limit = $this->config->get('config_catalog_limit');
-                }
+
+                $limit = $this->config->get('config_catalog_limit');
 
                 $sorting_href = $request['sort'];
                 if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/manufacturer.php
+++ b/public_html/storefront/controller/pages/product/manufacturer.php
@@ -132,7 +132,11 @@ class ControllerPagesProductManufacturer extends AController
                     $page = 1;
                 }
 
+              if (isset($this->request->get['limit'])) {
+                $limit = (int) $this->request->get['limit'];
+              } else {
                 $limit = $this->config->get('config_catalog_limit');
+              }
 
                 $sorting_href = $request['sort'];
                 if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/search.php
+++ b/public_html/storefront/controller/pages/product/search.php
@@ -123,13 +123,7 @@ class ControllerPagesProductSearch extends AController
         }
 
         $limit = $this->config->get('config_catalog_limit');
-        if (isset($request['limit']) && intval($request['limit']) > 0) {
-            $limit = intval($request['limit']);
-            if ($limit > 50) {
-                $limit = 50;
-            }
-        }
-
+    
         $sorting_href = $request['sort'];
         if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {
             $sorting_href = $this->config->get('config_product_default_sort_order');

--- a/public_html/storefront/controller/pages/product/search.php
+++ b/public_html/storefront/controller/pages/product/search.php
@@ -122,7 +122,11 @@ class ControllerPagesProductSearch extends AController
             $page = 1;
         }
 
-        $limit = $this->config->get('config_catalog_limit');
+        if (isset($this->request->get['limit'])) {
+            $limit = (int) $this->request->get['limit'];
+        } else {  
+            $limit = $this->config->get('config_catalog_limit');
+        } 
     
         $sorting_href = $request['sort'];
         if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/special.php
+++ b/public_html/storefront/controller/pages/product/special.php
@@ -93,7 +93,11 @@ class ControllerPagesProductSpecial extends AController
             $page = 1;
         }
 
-        $limit = $this->config->get('config_catalog_limit');
+        if (isset($this->request->get['limit'])) {
+            $limit = (int) $this->request->get['limit'];
+        } else {  
+            $limit = $this->config->get('config_catalog_limit');
+        }
 
         $sorting_href = $request['sort'];
         if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {

--- a/public_html/storefront/controller/pages/product/special.php
+++ b/public_html/storefront/controller/pages/product/special.php
@@ -93,12 +93,7 @@ class ControllerPagesProductSpecial extends AController
             $page = 1;
         }
 
-        if (isset($request['limit'])) {
-            $limit = (int) $request['limit'];
-            $limit = $limit > 50 ? 50 : $limit;
-        } else {
-            $limit = $this->config->get('config_catalog_limit');
-        }
+        $limit = $this->config->get('config_catalog_limit');
 
         $sorting_href = $request['sort'];
         if (!$sorting_href || !isset($this->data['sorts'][$request['sort']])) {


### PR DESCRIPTION
Apparently if we set the Default Items per Page (Storefront) to more than 50, the pagination limit is set to 50. That defeats the purpose of the Default Items per Page (Storefront) field.