### PR TITLE
Separate guest and logged in user order cancellation URL

### DIFF
--- a/public_html/extensions/fast_checkout/storefront/view/bootstrap5/template/responses/checkout/shipping_selector.tpl
+++ b/public_html/extensions/fast_checkout/storefront/view/bootstrap5/template/responses/checkout/shipping_selector.tpl
@@ -75,7 +75,7 @@ if($this->cart->hasShipping()){
             pageRequest(url, false);
         });
 
-        $(".shipping-selectors input[type='radio']").change(function () {
+        $(".shipping-selectors input:radio[name='shipping_method']").change(function () {
             let url = '<?php echo $main_url ?>&' + getUrlParams('shipping_method', $(this).val());
             if ($('#PayFrm').serialize()) {
                 url = '<?php echo $main_url ?>&' + $('#PayFrm').serialize()

--- a/public_html/extensions/fast_checkout/storefront/view/default/template/responses/checkout/payment.tpl
+++ b/public_html/extensions/fast_checkout/storefront/view/default/template/responses/checkout/payment.tpl
@@ -505,7 +505,7 @@ if ($show_payment == true) {
             pageRequest(url);
         });
 
-        $(".registerbox input[type='radio']").change(function () {
+        $(".registerbox input:radio[name='shipping_method']").change(function () {
             let url = '<?php echo $main_url ?>&' + getUrlParams('shipping_method', $(this).val());
             if ($('#PayFrm').serialize()) {
                 url = '<?php echo $main_url ?>&' + $('#PayFrm').serialize()

--- a/public_html/storefront/controller/pages/account/invoice.php
+++ b/public_html/storefront/controller/pages/account/invoice.php
@@ -314,10 +314,17 @@ class ControllerPagesAccountInvoice extends AController
                         ]
                     );
 
-                    $this->data['order_cancelation_url'] = $this->html->getSecureURL(
-                        'account/invoice/CancelOrder',
-                        '&order_id='.($guest ? $order_token : $order_id)
-                    );
+                    if (!$guest) {
+                        $this->data['order_cancelation_url'] = $this->html->getSecureURL(
+                            'account/invoice/CancelOrder',
+                            '&order_id='.$order_id
+                        );
+                    } else {
+                        $this->data['order_cancelation_url'] = $this->html->getSecureURL(
+                            'account/invoice/CancelOrder',
+                            '&ot='.$order_token
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
I found out that in the account/invoice order cancellation URL is using order_id instead of ot for guest, so i copied the code from fast checkout.