### PR TITLE
Update response/product/calculateTotal

### DIFF
--- a/public_html/storefront/controller/responses/product/product.php
+++ b/public_html/storefront/controller/responses/product/product.php
@@ -356,7 +356,7 @@ class ControllerResponsesProductProduct extends AController
 
         $output = [];
         //can not show price
-        if (!$this->config->get('config_customer_price') && !$this->customer->isLogged()) {
+        if (!$this->request->get['admin'] && !$this->config->get('config_customer_price') && !$this->customer->isLogged()) {
             $this->response->setOutput(AJson::encode($output));
             return;
         }


### PR DESCRIPTION
If Login to Disply Prices is enabled  and admin needs to add a product with  promotional pricing Admin does not get the promotional pricing even if conditions are met.  It seems Admin should always get the correct pricing including promotional regardeless of the login pricing requirement for customer.