### PR TITLE
ci: add minimium MariaDB/MySQL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,11 @@ jobs:
         php: [ '8.1', '8.2', '8.3' ]
         db:
           - ver: mysql
-            release: 8.0
+            release: '5.7'
+          - ver: mysql
+            release: latest
+          - ver: mariadb
+            release: 10.5
           - ver: mariadb
             release: latest
       fail-fast: false
@@ -47,7 +51,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Add a pause to be sure that ${{ matrix.db.ver}}
+      - name: Add a pause to be sure that ${{ matrix.db.ver}} is running
         run: to=15; until mysql -h 127.0.0.1 -u abantecart -pcartsarecool -e 'select 1' abantecart_test_build || [ $to -eq 0 ]; do sleep 1; echo not there yet - remaining $to; to=$(( to - 1 )); done; echo "ready"
 
       - name: Initialize ${{ matrix.db.ver }} Database


### PR DESCRIPTION
I see by your updated page you've listed minimum database versions

https://www.abantecart.com/ecommerce-getting-started

With a minimum listed it seem worth testing those.

MariaDB never had an 8 version, so I've used 10.5 (as the 10.4 version is almost out of maintenance - https://mariadb.org/about/#maintenance-policy) that has another full year of long term support.

Matching your MySQL descriptions I've used 5.7 and the latest (currently 8.4 - https://hub.docker.com/_/mysql).

The note "MySQL 8 requires PHP 7.4 or higher" looks odd as 8.0 is listed as the minimum PHP version.

I did try to do something more minimal as far the number of jobs but ran into a github action limitation - https://github.com/actions/runner/issues/3279.

PHP 8.0 could be added easily but it grows to [16 jobs](https://github.com/grooverdan/abantecart-src/actions/runs/9012507149).

Thanks for your support. I'll stop tinkering now so you can focus on UI and functional things.