### PR TITLE
add hooks to sf page, model and brand to admin product listing page

### DIFF
--- a/public_html/admin/controller/pages/catalog/product.php
+++ b/public_html/admin/controller/pages/catalog/product.php
@@ -68,6 +68,14 @@ class ControllerPagesCatalogProduct extends AController
             $this->data['categories'][$r['category_id']] = $r['name'];
         }
 
+        $this->loadModel('catalog/manufacturer');
+        $this->data['manufacturers'] = ['' => $this->language->get('text_select_manufacturer')];
+        $datas['store_id'] =  $this->session->data['current_store_id'];
+        $results = $this->model_catalog_manufacturer->getManufacturers($datas);
+        foreach ($results as $r) {
+            $this->data['manufacturers'][$r['manufacturer_id']] = $r['name'];
+        }
+
         $grid_settings = [
             'table_id'     => 'product_grid',
             'url'          => $this->html->getSecureURL(
@@ -188,7 +196,9 @@ class ControllerPagesCatalogProduct extends AController
         $grid_settings['colNames'] = [
             '',
             $this->language->get('column_name'),
+            $this->language->get('column_model'),
             $this->language->get('column_sku'),
+            $this->language->get('column_manufacturer'),
             $this->language->get('column_price'),
             $this->language->get('column_quantity'),
             $this->language->get('column_status'),
@@ -209,10 +219,23 @@ class ControllerPagesCatalogProduct extends AController
                 'width' => 200,
             ],
             [
+                'name'  => 'model',
+                'index' => 'model',
+                'align' => 'center',
+                'width' => 120,
+            ],
+            [
                 'name'  => 'sku',
                 'index' => 'sku',
                 'align' => 'center',
                 'width' => 120,
+            ],
+            [
+                'name'  => 'manufacturer',
+                'index' => 'manufacturer',
+                'align' => 'center',
+                'width' => 140,
+                'search' => false,
             ],
             [
                 'name'   => 'price',
@@ -332,6 +355,22 @@ class ControllerPagesCatalogProduct extends AController
                 'placeholder' => $this->language->get('text_select_category'),
             ]
         );
+
+        if ($this->request->get['manufacturer']) {
+            $search_params['manufacturer'] = $this->request->get['manufacturer'];
+        }
+
+        $grid_search_form['fields']['manufacturer'] = $form->getFieldHtml(
+            [
+                'type'        => 'selectbox',
+                'name'        => 'manufacturer',
+                'options'     => $this->data['manufacturers'],
+                'style'       => 'chosen',
+                'value'       => $search_params['manufacturer'],
+                'placeholder' => $this->language->get('text_select_manufacturer'),
+            ]
+        );
+
         $grid_search_form['fields']['status'] = $form->getFieldHtml(
             [
                 'type'        => 'selectbox',

--- a/public_html/admin/controller/responses/listing_grid/product.php
+++ b/public_html/admin/controller/responses/listing_grid/product.php
@@ -53,6 +53,7 @@ class ControllerResponsesListingGridProduct extends AController
         //Prepare filter config
         $filter_params = [
             'category',
+            'manufacturer',
             'status',
             'keyword',
             'match',
@@ -60,7 +61,7 @@ class ControllerResponsesListingGridProduct extends AController
             'pto',
         ];
 
-        $grid_filter_params = ['name', 'sort_order', 'sku'];
+        $grid_filter_params = ['name', 'sort_order', 'model', 'sku'];
 
         $filter_form = new AFilter(['method' => 'get', 'filter_params' => $filter_params]);
         $filter_grid = new AFilter(['method' => 'post', 'grid_filter_params' => $grid_filter_params]);
@@ -115,11 +116,18 @@ class ControllerResponsesListingGridProduct extends AController
                 ),
                 $this->html->buildInput(
                     [
+                        'name'  => 'model['.$result['product_id'].']',
+                        'value' => $result['model'],
+                    ]
+                ),
+                $this->html->buildInput(
+                    [
 
                         'name'  => 'sku['.$result['product_id'].']',
                         'value' => $result['sku'],
                     ]
                 ),
+                $result['manufacturer_name'],
                 $price,
                 (int) $result['quantity'],
                 $this->html->buildCheckbox(

--- a/public_html/admin/language/english/catalog/product.xml
+++ b/public_html/admin/language/english/catalog/product.xml
@@ -89,6 +89,10 @@
 		<value><![CDATA[Model]]></value>
 	</definition>
 	<definition>
+		<key>column_brand</key>
+		<value><![CDATA[Brand]]></value>
+	</definition>
+	<definition>
 		<key>column_sku</key>
 		<value><![CDATA[SKU]]></value>
 	</definition>
@@ -424,6 +428,10 @@
 	<definition>
 		<key>text_select_product</key>
 		<value><![CDATA[- Select Product -]]></value>
+	</definition>
+	<definition>
+		<key>text_select_manufacturer</key>
+		<value><![CDATA[- Select Brands -]]></value>
 	</definition>
 	<definition>
 		<key>text_option_name</key>

--- a/public_html/extensions/novator/storefront/view/novator/template/blocks/mega_menu_header_bottom.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/blocks/mega_menu_header_bottom.tpl
@@ -33,6 +33,7 @@ $categories = prepareNVCatItems($categories);
                 </div>
             </div>
             <?php } ?>
+            <?php echo $this->getHookVar('categories_additional_info'); ?>
             <div class="collapse d-none d-lg-flex navbar-collapse ">
                 <ul class="mega-sf-menu navbar-nav mx-auto mb-2 mb-lg-0 align-items-start flex-wrap">
                     <?php

--- a/public_html/extensions/novator/storefront/view/novator/template/blocks/product_card.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/blocks/product_card.tpl
@@ -49,6 +49,7 @@
                                     <i class="bi bi-shuffle"></i>
                                 </a>
                             </li>
+                            <?php echo $this->getHookvar('product_button_'.$product['product_id']); ?>
                         </ul>
                     </div>
                     <div class="col-auto">

--- a/public_html/extensions/novator/storefront/view/novator/template/blocks/product_listing.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/blocks/product_listing.tpl
@@ -94,6 +94,7 @@
                                                     <i class="bi bi-shuffle"></i>
                                                 </a>
                                             </li>
+                                            <?php echo $this->getHookvar('product_button_'.$product['product_id']); ?>
                                         </ul>
 
                                         <div class="d-flex justify-content-center p-1 mt-2 align-items-center">

--- a/public_html/extensions/novator/storefront/view/novator/template/blocks/product_multiple_carousel.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/blocks/product_multiple_carousel.tpl
@@ -106,6 +106,7 @@ if($products){ ?>
                                                                         <i class="bi bi-shuffle"></i>
                                                                     </a>
                                                                 </li>
+                                                                <?php echo $this->getHookvar('product_button_'.$product['product_id']); ?>
                                                             </ul>
                                                         </div>
                                                         <div class="col-auto">

--- a/public_html/extensions/novator/storefront/view/novator/template/common/header.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/common/header.tpl
@@ -100,6 +100,7 @@
                     </div>
                 </div>
                 <?php }?>
+                <?php echo $this->getHookVar('categories_additional_info'); ?>
                 <div class="accordion-item">
                     <h2 class="accordion-header">
                         <a href="<?php echo $this->html->getSecureUrl('product/special') ?>" class="accordion-button collapsed no-icon"><?php echo $text_special;?>

--- a/public_html/extensions/novator/storefront/view/novator/template/pages/account/account.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/pages/account/account.tpl
@@ -77,7 +77,9 @@
         foreach($array as $key => $item){
             if($key == 'download' && !$this->config->get('config_download')){ continue; }
             //hookvar before
-            if($key == 'wishlist'){
+            if($key == 'history'){
+                echo $this->getHookVar('account_links_dash_icons');
+            }elseif($key == 'wishlist'){
                 echo $this->getHookVar('account_dash_icons');
             }elseif($key == 'logout'){
                 echo $this->getHookVar('account_newsletter_dash_icons');

--- a/public_html/install/abantecart_database_upgrade.sql
+++ b/public_html/install/abantecart_database_upgrade.sql
@@ -1,0 +1,2 @@
+INSERT INTO `ac_language_definitions` (`language_id`, `section`, `block`, `language_key`, `language_value`, `date_added`, `date_modified`) VALUES
+    ('1','1','catalog_product','text_select_manufacturer','- Select Brands -',NOW(),NOW());


### PR DESCRIPTION
Hi core devs,
we found out that you have removed model from the product listing grid.

while our customer use both model and SKU for different purpose. with that said we like to propose to add back the model in the admin product listing page. in addition i add brands so admin can filter the products by brand as well.