### PR TITLE
ACORN-1707 flexy_forms: registered checkout ignores empty required fields

### DIFF
--- a/public_html/extensions/novator/storefront/view/novator/template/responses/checkout/address_cards_logged.tpl
+++ b/public_html/extensions/novator/storefront/view/novator/template/responses/checkout/address_cards_logged.tpl
@@ -66,7 +66,7 @@ if ($show_payment) {
     $readonly = count((array)$csession['shipping_methods']) == 1 ? ' readonly ' : '' ;
 ?>
     <div class="flex-item flex-fill ps-0 pt-0 pb-1">
-        <h4 class="shipping_address_label mt-2"><?php echo $fast_checkout_text_payment_address; ?></h4>
+        <h4 class="shipping_address_label mt-2 mt-lg-0"><?php echo $fast_checkout_text_payment_address; ?></h4>
         <div class="input-group">
             <div class="input-group-text">
                 <i class="fa fa-bank" id="delivery_icon"></i>

--- a/public_html/storefront/controller/responses/checkout/pay.php
+++ b/public_html/storefront/controller/responses/checkout/pay.php
@@ -458,6 +458,9 @@ class ControllerResponsesCheckoutPay extends AController
         if (isset($this->error['message'])) {
             $this->data['error'] = $this->error['message'];
         }
+        if (!empty($this->data['error'])) {
+            $this->data['payment_form'] = false;
+        }
 
         //pass cart session to template view
         $this->data['csession'] = $this->fc_session;


### PR DESCRIPTION
Checkout no longer skips the address validation error + leveled layout of columns "Delivery Address"
 and "Payment Address" 