### PR TITLE
ACORN-1945 admin: can not disable extension

### DIFF
--- a/public_html/admin/controller/responses/listing_grid/extension.php
+++ b/public_html/admin/controller/responses/listing_grid/extension.php
@@ -360,6 +360,9 @@ class ControllerResponsesListingGridExtension extends AController
 
         if (empty($this->request->get['id'])) {
             foreach ($this->request->post as $ext => $val) {
+                if (!is_array($val)) {
+                    continue;
+                }
                 $val['store_id'] = $store_id;
                 $this->extension_manager->editSetting($ext, $val);
             }


### PR DESCRIPTION
Added a guard to skip non-array POST items in listing_grid/extension::update(), preventing a PHP 8 fatal error when unexpected scalar fields appear in bulk status updates