### PR TITLE
ACORN-1950 paypal: getPaypalCharge(): Return value must be of type ?object, array returned

### DIFF
--- a/public_html/extensions/paypal_commerce/admin/model/extension/paypal_commerce.php
+++ b/public_html/extensions/paypal_commerce/admin/model/extension/paypal_commerce.php
@@ -18,7 +18,6 @@
  *    needs, please refer to http://www.AbanteCart.com for more information.
  */
 
-use PaypalServerSdkLib\ApiHelper;
 use PaypalServerSdkLib\Models\CapturedPayment;
 use PaypalServerSdkLib\Models\CaptureRequest;
 use PaypalServerSdkLib\Models\Money;
@@ -99,20 +98,7 @@ class ModelExtensionPaypalCommerce extends Model
         }
 
         $apiResponse = $this->paypal->getOrdersController()->getOrder(['id'=>$ch_id]);
-        $result = $apiResponse->getResult();
-        if ($result instanceof Order) {
-            return $result;
-        }
-        if (is_array($result)) {
-            try {
-                $mappedResult = ApiHelper::getJsonHelper()->mapClass($result, Order::class);
-                return $mappedResult instanceof Order ? $mappedResult : null;
-            } catch (Exception|Error) {
-                return null;
-            }
-        }
-
-        return null;
+        return paypalNormalizeOrderResult($apiResponse->getResult());
     }
 
     /**

--- a/public_html/extensions/paypal_commerce/admin/model/extension/paypal_commerce.php
+++ b/public_html/extensions/paypal_commerce/admin/model/extension/paypal_commerce.php
@@ -18,9 +18,11 @@
  *    needs, please refer to http://www.AbanteCart.com for more information.
  */
 
+use PaypalServerSdkLib\ApiHelper;
 use PaypalServerSdkLib\Models\CapturedPayment;
 use PaypalServerSdkLib\Models\CaptureRequest;
 use PaypalServerSdkLib\Models\Money;
+use PaypalServerSdkLib\Models\Order;
 use PaypalServerSdkLib\Models\PaymentAuthorization;
 use PaypalServerSdkLib\Models\Refund;
 use PaypalServerSdkLib\Models\RefundRequest;
@@ -86,16 +88,31 @@ class ModelExtensionPaypalCommerce extends Model
     /**
      * @param string $ch_id
      *
-     * @return PaypalServerSdkLib\Models\Order|null
+     * @return Order|null
+     *
+     * If API result comes as array, it is mapped to Order.
      */
-    public function getPaypalCharge($ch_id): ?object
+    public function getPaypalCharge($ch_id): ?Order
     {
         if (!has_value($ch_id)) {
             return null;
         }
 
         $apiResponse = $this->paypal->getOrdersController()->getOrder(['id'=>$ch_id]);
-        return $apiResponse->getResult();
+        $result = $apiResponse->getResult();
+        if ($result instanceof Order) {
+            return $result;
+        }
+        if (is_array($result)) {
+            try {
+                $mappedResult = ApiHelper::getJsonHelper()->mapClass($result, Order::class);
+                return $mappedResult instanceof Order ? $mappedResult : null;
+            } catch (Exception|Error) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/public_html/extensions/paypal_commerce/core/paypal_commerce_modules.php
+++ b/public_html/extensions/paypal_commerce/core/paypal_commerce_modules.php
@@ -19,10 +19,12 @@
  */
 
 use PaypalServerSdkLib\Authentication\ClientCredentialsAuthCredentialsBuilder;
+use PaypalServerSdkLib\ApiHelper;
 use PaypalServerSdkLib\Environment;
 use PaypalServerSdkLib\Logging\LoggingConfigurationBuilder;
 use PaypalServerSdkLib\Logging\RequestLoggingConfigurationBuilder;
 use PaypalServerSdkLib\Logging\ResponseLoggingConfigurationBuilder;
+use PaypalServerSdkLib\Models\Order;
 use PaypalServerSdkLib\PaypalServerSdkClient;
 use PaypalServerSdkLib\PaypalServerSdkClientBuilder;
 use Psr\Log\LogLevel;
@@ -83,4 +85,28 @@ function getNonce(string $uniqueID, bool $urlencoded = true)
         $uniqueID = str_pad($uniqueID, 44, '0', STR_PAD_RIGHT);
     }
     return $uniqueID;
+}
+
+/**
+ * Normalize PayPal SDK order result to a typed Order model.
+ *
+ * @param mixed $result
+ *
+ * @return Order|null
+ */
+function paypalNormalizeOrderResult($result): ?Order
+{
+    if ($result instanceof Order) {
+        return $result;
+    }
+    if (!is_array($result)) {
+        return null;
+    }
+
+    try {
+        $mappedResult = ApiHelper::getJsonHelper()->mapClass($result, Order::class);
+        return $mappedResult instanceof Order ? $mappedResult : null;
+    } catch (Exception|Error) {
+        return null;
+    }
 }

--- a/public_html/extensions/paypal_commerce/storefront/model/extension/paypal_commerce.php
+++ b/public_html/extensions/paypal_commerce/storefront/model/extension/paypal_commerce.php
@@ -21,6 +21,7 @@
 /** @noinspection PhpUndefinedClassInspection */
 
 use PaypalServerSdkLib\Http\ApiResponse;
+use PaypalServerSdkLib\Models\Order;
 
 if (!defined('DIR_CORE')) {
     header('Location: static_pages/');
@@ -178,9 +179,11 @@ class ModelExtensionPaypalCommerce extends Model
     /**
      * @param string $paypalOrderId
      *
-     * @return PaypalServerSdkLib\Models\Order|false
+     * @return Order|null
+     *
+     * If API result comes as array, it is mapped to Order.
      */
-    public function getOrder(string $paypalOrderId): ?object
+    public function getOrder(string $paypalOrderId): ?Order
     {
         if ($paypalOrderId === '') {
             return null;
@@ -190,7 +193,20 @@ class ModelExtensionPaypalCommerce extends Model
             ->getOrdersController()
             ->getOrder(['id' => $paypalOrderId]);
 
-        return $apiResponse->getResult();
+        $result = $apiResponse->getResult();
+        if ($result instanceof Order) {
+            return $result;
+        }
+        if (is_array($result)) {
+            try {
+                $mappedResult = \PaypalServerSdkLib\ApiHelper::getJsonHelper()->mapClass($result, Order::class);
+                return $mappedResult instanceof Order ? $mappedResult : null;
+            } catch (Exception|Error) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/public_html/extensions/paypal_commerce/storefront/model/extension/paypal_commerce.php
+++ b/public_html/extensions/paypal_commerce/storefront/model/extension/paypal_commerce.php
@@ -193,20 +193,7 @@ class ModelExtensionPaypalCommerce extends Model
             ->getOrdersController()
             ->getOrder(['id' => $paypalOrderId]);
 
-        $result = $apiResponse->getResult();
-        if ($result instanceof Order) {
-            return $result;
-        }
-        if (is_array($result)) {
-            try {
-                $mappedResult = \PaypalServerSdkLib\ApiHelper::getJsonHelper()->mapClass($result, Order::class);
-                return $mappedResult instanceof Order ? $mappedResult : null;
-            } catch (Exception|Error) {
-                return null;
-            }
-        }
-
-        return null;
+        return paypalNormalizeOrderResult($apiResponse->getResult());
     }
 
     /**


### PR DESCRIPTION
update getPaypalCharge and getOrder methods to return Order type and handle array mapping