### PR TITLE
ACORN-1653 Control Panel Session Expiration setting ignored - Documentation update

### DIFF
--- a/public_html/admin/controller/common/head.php
+++ b/public_html/admin/controller/common/head.php
@@ -41,8 +41,7 @@ class  ControllerCommonHead extends AController
         $this->data['scripts'] = $this->document->getScripts();
         $this->data['notifier_updater_url'] = $this->html->getSecureURL('listing_grid/message_grid/getnotifies');
         $this->data['system_checker_url'] = $this->html->getSecureURL('common/common/checksystem');
-        $autoRefresh = $this->config->get('config_admin_background_autorefresh');
-        $this->data['admin_background_autorefresh_enabled'] = $autoRefresh === null || $autoRefresh === '' || (int)$autoRefresh === 1;
+        $this->data['admin_background_autorefresh_enabled'] = $this->config->get('config_admin_background_autorefresh');
         $this->data['language_code'] = $this->session->data['language'];
         $this->data['language_details'] = $this->language->getCurrentLanguage();
         $locale = explode('.', $this->data['language_details']['locale']);

--- a/public_html/admin/controller/common/head.php
+++ b/public_html/admin/controller/common/head.php
@@ -41,7 +41,8 @@ class  ControllerCommonHead extends AController
         $this->data['scripts'] = $this->document->getScripts();
         $this->data['notifier_updater_url'] = $this->html->getSecureURL('listing_grid/message_grid/getnotifies');
         $this->data['system_checker_url'] = $this->html->getSecureURL('common/common/checksystem');
-        $this->data['admin_background_autorefresh_enabled'] = $this->config->get('config_admin_background_autorefresh');
+        $autoRefresh = $this->config->get('config_admin_background_autorefresh');
+        $this->data['admin_background_autorefresh_enabled'] = $autoRefresh === null || $autoRefresh === '' || (int)$autoRefresh === 1;
         $this->data['language_code'] = $this->session->data['language'];
         $this->data['language_details'] = $this->language->getCurrentLanguage();
         $locale = explode('.', $this->data['language_details']['locale']);

--- a/public_html/admin/language/english/setting/setting.xml
+++ b/public_html/admin/language/english/setting/setting.xml
@@ -489,7 +489,7 @@
 		<definition>
 			<key>entry_admin_background_autorefresh</key>
 			<value>
-					<![CDATA[Keep Long Session:<br /><span class="help">Enable periodic background requests for admin notifications and system checks. Disable this to prevent background refresh from extending active session.</span>]]></value>
+					<![CDATA[Keep Long Session:<br /><span class="help">Enable periodic background requests for admin notifications and system checks. Disable this to prevent background refresh from extending active session. After changing this setting, you may see a one-time re-login prompt.</span>]]></value>
 		</definition>
 		<definition>
 			<key>entry_encryption</key>


### PR DESCRIPTION
docs: update help text for Keep Long Session setting to clarify re-login prompt