### PR TITLE
ACORN-1968 paypal: missing name

### DIFF
--- a/public_html/extensions/paypal_commerce/storefront/controller/responses/extension/paypal_commerce.php
+++ b/public_html/extensions/paypal_commerce/storefront/controller/responses/extension/paypal_commerce.php
@@ -507,8 +507,8 @@ class ControllerResponsesExtensionPaypalCommerce extends AController
 
         $this->data['pp']['payer'] = [
             'name'          => [
-                'given_name' => $order_info['shipping_firstname'],
-                'surname'    => $order_info['shipping_lastname'],
+                'given_name' => $order_info['payment_firstname'] ?: $order_info['shipping_firstname'] ?: $order_info['firstname'],
+                'surname'    => $order_info['payment_lastname'] ?: $order_info['shipping_lastname'] ?: $order_info['lastname'],
             ],
             'email_address' => $order_info['email'],
         ];


### PR DESCRIPTION
Fix PayPal Card Fields missing payer name for no-shipping orders