### PR TITLE
ACORN-1971 admin: category grid Status Quick change not working

### DIFF
--- a/public_html/admin/view/default/javascript/aform.js
+++ b/public_html/admin/view/default/javascript/aform.js
@@ -252,11 +252,11 @@
 		function doSwitchButton(elem) {
 			var $field = $(elem);
 			var $wrapper = $field.parent('.afield');
-			$wrapper.find('button').not('[readonly]').on( "click" ,function () {
+			$wrapper.off('click.aformSwitch').on('click.aformSwitch', 'button:not([readonly])', function () {
 				if($field.hasClass('disabled')){
 					return false;
 				}
-					flip_aswitch($field);
+				flip_aswitch($field);
 				onChangedAction($field, $field.val(), $field.attr('data-orgvalue'));
 				return false;
 			});


### PR DESCRIPTION
Fix category status toggle in the admin list after expanding parent categories