### PR TITLE
ACORN-2033 admin: Blocks grid column name

### DIFF
--- a/public_html/admin/controller/pages/design/blocks.php
+++ b/public_html/admin/controller/pages/design/blocks.php
@@ -79,7 +79,7 @@ class ControllerPagesDesignBlocks extends AController
 
         $grid_settings['colNames'] = [
             $this->language->get('column_block_id'),
-            $this->language->get('column_block_txt_id'),
+            $this->language->get('column_block_type'),
             $this->language->get('column_block_name'),
             $this->language->get('column_status'),
             $this->language->get('column_date_modified'),


### PR DESCRIPTION
ACORN-2033 admin: change Blocks grid column header from "Unique Text ID" to "Type"